### PR TITLE
flexibilize deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.4",
         "xiag/json-command": "~0.1.0",
-        "symfony/framework-bundle": "~2.6",
+        "symfony/framework-bundle": "~2.7 || ^3.0",
         "jms/serializer-bundle": ">=1.0"
     },
     "require-dev": {


### PR DESCRIPTION
@mrix we want to go forwards to symfony ~3, please update your `composer.json` and release a new tag ;-) i already deployed it with this fix (with `dev-feature/*` dependencies), and it works fine..